### PR TITLE
Correctif gestion des droits

### DIFF
--- a/app/core/Access.class.php
+++ b/app/core/Access.class.php
@@ -120,8 +120,8 @@ class Access extends Singleton
 		            	$perms[] = $module;
                         $perms[] = '*';
 		            }
+		            $access = (!!array_intersect($perms, $rules));
 		        }
-		        $access = (!!array_intersect($perms, $rules));
 		        $return = ($strict) ? ($return && $access) : ($return || $access);
 		    }
 		    return $return;


### PR DESCRIPTION
Une erreur survenait lorsque l'identifiant de gestion droit n'était pas renseigné.